### PR TITLE
test: validate apply flow end-to-end

### DIFF
--- a/iac/prod/github/terragrunt.stack.hcl
+++ b/iac/prod/github/terragrunt.stack.hcl
@@ -85,7 +85,7 @@ unit "repo-packer-images" {
   path   = "repo-packer-images"
   values = {
     name        = "packer-images"
-    description = "Packer Images for proxmox VM"
+    description = "Packer images for Proxmox VMs"
     topics      = local.base_repos_topics
     codeowners = [
       "* @proxmox-home-lab/platform",


### PR DESCRIPTION
## Summary
- Minor description fix on `packer-images` to test the full plan → merge → apply flow end-to-end with the latest CI fixes:
  - `TG_NON_INTERACTIVE=false` on apply step (OpenTofu v1.11 `-auto-approve` + plan file fix)
  - `show-plan` job removed, artifact resolution inlined into `apply`
  - `tg-summarize` regex fix for `to import` plans

## Test plan
- [ ] Plan runs and posts PR comment with 1 unit changed (`repo-packer-images`)
- [ ] Merge PR → apply triggers automatically
- [ ] Apply succeeds with the plan artifact from this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)