### PR TITLE
fix(github-stack): rename github_app_installation_id → github_app_id

### DIFF
--- a/iac/prod/github/terragrunt.stack.hcl
+++ b/iac/prod/github/terragrunt.stack.hcl
@@ -6,7 +6,7 @@ locals {
     ["base"]
   )
 
-  github_app_installation_id = get_env("GITHUB_APP_ID", "0")
+  github_app_id = get_env("GITHUB_APP_ID", "0")
 
   default_bypass_actors = [
     {
@@ -16,7 +16,7 @@ locals {
     },
     {
       actor_type  = "Integration"
-      actor_id    = local.github_app_installation_id
+      actor_id    = local.github_app_id
       bypass_mode = "always"
     },
   ]


### PR DESCRIPTION
## Summary

- Renames the `github_app_installation_id` local to `github_app_id` — the value it holds is the **App ID** (1700699), not the installation ID (78452327)

## Why this PR triggers the apply we need

Merging this will trigger the `plan-for-apply → apply` pipeline. The apply will pick up:
1. This rename (no-op in terms of actual resource changes)
2. The new `github_team_repository` resource from infrastructure-catalog PR #18 (now on `main`) — this grants `@proxmox-home-lab/platform` push access to every repo, fixing the CODEOWNERS validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)